### PR TITLE
Fix failed lro cases

### DIFF
--- a/packages/autorest.typescript/src/generators/operationGenerator.ts
+++ b/packages/autorest.typescript/src/generators/operationGenerator.ts
@@ -972,7 +972,7 @@ function writeLroOperationBody(
         ? `new LroEngine(lro, { resumeFrom: options?.resumeFrom, ${commonOptions} })`
         : `await createHttpPoller<${responseName}, OperationState<${responseName}>>(lro, { restoreFrom: options?.resumeFrom, ${commonOptions} })`
     };`,
-    "await poller.poll();",
+    useLegacyLro ? "await poller.poll();" : "",
     "return poller;"
   ]);
 

--- a/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/dataFlowDebugSession.ts
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/dataFlowDebugSession.ts
@@ -196,7 +196,7 @@ export class DataFlowDebugSessionImpl implements DataFlowDebugSession {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -346,7 +346,7 @@ export class DataFlowDebugSessionImpl implements DataFlowDebugSession {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/integrationRuntimeObjectMetadata.ts
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/integrationRuntimeObjectMetadata.ts
@@ -98,7 +98,7 @@ export class IntegrationRuntimeObjectMetadataImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/integrationRuntimes.ts
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/integrationRuntimes.ts
@@ -432,7 +432,7 @@ export class IntegrationRuntimesImpl implements IntegrationRuntimes {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -519,7 +519,7 @@ export class IntegrationRuntimesImpl implements IntegrationRuntimes {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/triggers.ts
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/src/operations/triggers.ts
@@ -296,7 +296,7 @@ export class TriggersImpl implements Triggers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -410,7 +410,7 @@ export class TriggersImpl implements Triggers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -497,7 +497,7 @@ export class TriggersImpl implements Triggers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -584,7 +584,7 @@ export class TriggersImpl implements Triggers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/src/operations/iotDpsResource.ts
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/src/operations/iotDpsResource.ts
@@ -464,7 +464,7 @@ export class IotDpsResourceImpl implements IotDpsResource {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -567,7 +567,7 @@ export class IotDpsResourceImpl implements IotDpsResource {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -653,7 +653,7 @@ export class IotDpsResourceImpl implements IotDpsResource {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -962,7 +962,7 @@ export class IotDpsResourceImpl implements IotDpsResource {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1065,7 +1065,7 @@ export class IotDpsResourceImpl implements IotDpsResource {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/domainservices/src/operations/domainServices.ts
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/src/operations/domainServices.ts
@@ -269,7 +269,7 @@ export class DomainServicesImpl implements DomainServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -376,7 +376,7 @@ export class DomainServicesImpl implements DomainServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -471,7 +471,7 @@ export class DomainServicesImpl implements DomainServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/domainservices/src/operations/ouContainerOperationGrp.ts
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/src/operations/ouContainerOperationGrp.ts
@@ -238,7 +238,7 @@ export class OuContainerOperationGrpImpl implements OuContainerOperationGrp {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -331,7 +331,7 @@ export class OuContainerOperationGrpImpl implements OuContainerOperationGrp {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -436,7 +436,7 @@ export class OuContainerOperationGrpImpl implements OuContainerOperationGrp {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/dicomServices.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/dicomServices.ts
@@ -237,7 +237,7 @@ export class DicomServicesImpl implements DicomServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class DicomServicesImpl implements DicomServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -433,7 +433,7 @@ export class DicomServicesImpl implements DicomServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/fhirServices.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/fhirServices.ts
@@ -237,7 +237,7 @@ export class FhirServicesImpl implements FhirServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class FhirServicesImpl implements FhirServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -433,7 +433,7 @@ export class FhirServicesImpl implements FhirServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/iotConnectorFhirDestination.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/iotConnectorFhirDestination.ts
@@ -139,7 +139,7 @@ export class IotConnectorFhirDestinationImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -241,7 +241,7 @@ export class IotConnectorFhirDestinationImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/iotConnectors.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/iotConnectors.ts
@@ -237,7 +237,7 @@ export class IotConnectorsImpl implements IotConnectors {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class IotConnectorsImpl implements IotConnectors {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -433,7 +433,7 @@ export class IotConnectorsImpl implements IotConnectors {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/privateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/privateEndpointConnections.ts
@@ -222,7 +222,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -319,7 +319,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/services.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/services.ts
@@ -256,7 +256,7 @@ export class ServicesImpl implements Services {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -356,7 +356,7 @@ export class ServicesImpl implements Services {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -441,7 +441,7 @@ export class ServicesImpl implements Services {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/workspaces.ts
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/src/operations/workspaces.ts
@@ -281,7 +281,7 @@ export class WorkspacesImpl implements Workspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -381,7 +381,7 @@ export class WorkspacesImpl implements Workspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -466,7 +466,7 @@ export class WorkspacesImpl implements Workspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/lro/src/operations/lRORetrys.ts
+++ b/packages/autorest.typescript/test/integration/generated/lro/src/operations/lRORetrys.ts
@@ -120,7 +120,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -210,7 +210,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -302,7 +302,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -393,7 +393,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -481,7 +481,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -569,7 +569,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -658,7 +658,7 @@ export class LRORetrysImpl implements LRORetrys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROs.ts
+++ b/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROs.ts
@@ -190,10 +190,9 @@ export class LROsImpl implements LROs {
       OperationState<LROsPut200SucceededResponse>
     >(lro, {
       restoreFrom: options?.resumeFrom,
-      intervalInMs: options?.updateIntervalInMs,
-      resolveOnUnsuccessful: false
+      intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -281,7 +280,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -369,7 +368,7 @@ export class LROsImpl implements LROs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -456,7 +455,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -546,7 +545,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -634,7 +633,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -722,7 +721,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -810,7 +809,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -899,7 +898,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -989,7 +988,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1079,7 +1078,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1169,7 +1168,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1258,7 +1257,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1347,7 +1346,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1437,7 +1436,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1527,7 +1526,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1617,7 +1616,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1706,7 +1705,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1793,7 +1792,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1879,7 +1878,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1965,7 +1964,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2051,7 +2050,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2139,7 +2138,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2231,7 +2230,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2323,7 +2322,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2403,7 +2402,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2490,7 +2489,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2578,7 +2577,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2666,7 +2665,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2754,7 +2753,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2842,7 +2841,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2930,7 +2929,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3018,7 +3017,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3106,7 +3105,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3194,7 +3193,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3282,7 +3281,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3370,7 +3369,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3459,7 +3458,7 @@ export class LROsImpl implements LROs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3549,7 +3548,7 @@ export class LROsImpl implements LROs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3641,7 +3640,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3733,7 +3732,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3823,7 +3822,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3913,7 +3912,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -4003,7 +4002,7 @@ export class LROsImpl implements LROs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROs.ts
+++ b/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROs.ts
@@ -190,7 +190,8 @@ export class LROsImpl implements LROs {
       OperationState<LROsPut200SucceededResponse>
     >(lro, {
       restoreFrom: options?.resumeFrom,
-      intervalInMs: options?.updateIntervalInMs
+      intervalInMs: options?.updateIntervalInMs,
+      resolveOnUnsuccessful: false
     });
     await poller.poll();
     return poller;

--- a/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROsCustomHeader.ts
+++ b/packages/autorest.typescript/test/integration/generated/lro/src/operations/lROsCustomHeader.ts
@@ -115,7 +115,7 @@ export class LROsCustomHeaderImpl implements LROsCustomHeader {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -207,7 +207,7 @@ export class LROsCustomHeaderImpl implements LROsCustomHeader {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -298,7 +298,7 @@ export class LROsCustomHeaderImpl implements LROsCustomHeader {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -389,7 +389,7 @@ export class LROsCustomHeaderImpl implements LROsCustomHeader {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/lro/src/operations/lrosaDs.ts
+++ b/packages/autorest.typescript/test/integration/generated/lro/src/operations/lrosaDs.ts
@@ -155,7 +155,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -242,7 +242,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -330,7 +330,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -420,7 +420,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -507,7 +507,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -593,7 +593,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -680,7 +680,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -767,7 +767,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -853,7 +853,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -940,7 +940,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1027,7 +1027,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1117,7 +1117,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1207,7 +1207,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1287,7 +1287,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1374,7 +1374,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1461,7 +1461,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1549,7 +1549,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1638,7 +1638,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1726,7 +1726,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1815,7 +1815,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1906,7 +1906,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1994,7 +1994,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2084,7 +2084,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2174,7 +2174,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2263,7 +2263,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2353,7 +2353,7 @@ export class LrosaDsImpl implements LrosaDs {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClient.ts
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClient.ts
@@ -126,7 +126,7 @@ export class LroParametrizedEndpointsClient extends coreClient.ServiceClient {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -211,7 +211,7 @@ export class LroParametrizedEndpointsClient extends coreClient.ServiceClient {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClient.ts
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClient.ts
@@ -179,7 +179,7 @@ export class MediaTypesV3LROClient extends coreClient.ServiceClient {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/paging/src/operations/paging.ts
+++ b/packages/autorest.typescript/test/integration/generated/paging/src/operations/paging.ts
@@ -2153,7 +2153,7 @@ export class PagingImpl implements Paging {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/src/operations/paging.ts
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/src/operations/paging.ts
@@ -466,7 +466,7 @@ export class PagingImpl implements Paging {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/integration/lro.spec.ts
+++ b/packages/autorest.typescript/test/integration/lro.spec.ts
@@ -29,7 +29,7 @@ const LROOptions = {
   onResponse: onResponse
 };
 
-describe("LROs", () => {
+describe.only("LROs", () => {
   let client: LROClient;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe("LROs", () => {
   });
 
   describe("Pipeline validation", () => {
-    it("should execute custom pipeline when passed in a factory array", async () => {
+    it.only("should execute custom pipeline when passed in a factory array", async () => {
       let calledCustomPolicy = false;
       const customPolicy: PipelinePolicy = {
         name: "customPolicy",

--- a/packages/autorest.typescript/test/integration/lro.spec.ts
+++ b/packages/autorest.typescript/test/integration/lro.spec.ts
@@ -29,7 +29,7 @@ const LROOptions = {
   onResponse: onResponse
 };
 
-describe.only("LROs", () => {
+describe("LROs", () => {
   let client: LROClient;
 
   beforeEach(() => {
@@ -38,7 +38,7 @@ describe.only("LROs", () => {
   });
 
   describe("Pipeline validation", () => {
-    it.only("should execute custom pipeline when passed in a factory array", async () => {
+    it("should execute custom pipeline when passed in a factory array", async () => {
       let calledCustomPolicy = false;
       const customPolicy: PipelinePolicy = {
         name: "customPolicy",
@@ -235,7 +235,7 @@ describe.only("LROs", () => {
     });
 
     it("should handle deleteProvisioning202Accepted200Succeeded", async () => {
-      await client.lROs.beginDeleteProvisioning202Accepted200Succeeded(
+      await client.lROs.beginDeleteProvisioning202Accepted200SucceededAndWait(
         LROOptions
       );
       check200(lastResponse);

--- a/packages/autorest.typescript/test/rlcIntegration/dpgCustomizationRest.spec.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/dpgCustomizationRest.spec.ts
@@ -44,7 +44,7 @@ describe("DPGCustomization Client", () => {
       const initialResponse = await client
         .path("/customization/lro/{mode}", "raw")
         .put();
-      const poller = getLongRunningPoller(client, initialResponse);
+      const poller = await getLongRunningPoller(client, initialResponse);
       const result = await poller.pollUntilDone();
       assert.equal(result.status, "200");
     });
@@ -81,7 +81,7 @@ describe("DPGCustomization Client", () => {
       const initialResponse = await client
         .path("/customization/lro/{mode}", "model")
         .put();
-      const poller = getLongRunningPoller(client, initialResponse);
+      const poller = await getLongRunningPoller(client, initialResponse);
       const result = await poller.pollUntilDone();
       assert.equal(result.status, "200");
     });

--- a/packages/autorest.typescript/test/rlcIntegration/lroRest.spec.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/lroRest.spec.ts
@@ -27,7 +27,7 @@ describe("LRO Rest Client", () => {
   describe("BodyPolling Strategy", () => {
     it("should handle initial response with terminal state through an Azure Resource", async () => {
       const initialResponse = await client.path("/lro/put/200/succeeded").put();
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -40,7 +40,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/put/200/succeeded/nostate")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -60,7 +60,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/put/201/creating/succeeded/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -82,7 +82,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/put/200/accepted/canceled/200")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -98,7 +98,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/put/200/updating/succeeded/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -119,7 +119,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/put/201/created/failed/200")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -137,7 +137,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/post/202/retry/200")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -150,7 +150,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/post/202/noretry/204")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -164,7 +164,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/noheader")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -176,7 +176,7 @@ describe("LRO Rest Client", () => {
     it("should handle put202Retry200", async () => {
       const initialResponse = await client.path("/lro/put/202/retry/200").put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -190,7 +190,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/put/noheader/202/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -203,7 +203,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putsubresource/202/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -216,7 +216,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putnonresource/202/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -229,7 +229,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/202/retry/200")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -243,7 +243,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/202/noretry/204")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -257,7 +257,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/provisioning/202/accepted/200/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -270,7 +270,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/provisioning/202/deleting/200/failed")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -288,7 +288,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/provisioning/202/deleting/200/canceled")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -308,7 +308,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/delete/204/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -333,7 +333,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/LROPostDoubleHeadersFinalLocationGet")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -347,9 +347,9 @@ describe("LRO Rest Client", () => {
         .path("/lro/LROPostDoubleHeadersFinalAzureHeaderGet")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0,
-        lroResourceLocationConfig: "azure-async-operation"
+        resourceLocationConfig: "azure-async-operation"
       });
 
       const result = await poller.pollUntilDone();
@@ -359,7 +359,7 @@ describe("LRO Rest Client", () => {
     it("should handle post200WithPayload", async () => {
       const initialResponse = await client.path("/lro/post/payload/200").post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -378,7 +378,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -391,7 +391,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/deleteasync/retry/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -404,7 +404,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/deleteasync/noretry/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -418,7 +418,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/deleteasync/retry/canceled")
           .delete();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -435,7 +435,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/deleteasync/retry/failed")
           .delete();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -451,7 +451,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putasync/retry/succeeded")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -469,7 +469,7 @@ describe("LRO Rest Client", () => {
     it("should handle put201Succeeded", async () => {
       const initialResponse = await client.path("/lro/put/201/succeeded").put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -487,7 +487,7 @@ describe("LRO Rest Client", () => {
     it("should handle post202List", async () => {
       const initialResponse = await client.path("/lro/list").post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -512,7 +512,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/putasync/retry/failed")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -528,7 +528,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putnonresourceasync/202/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -541,7 +541,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putasync/noheader/201/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -554,7 +554,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putasync/noretry/succeeded")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -575,7 +575,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/putasync/noretry/canceled")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -591,7 +591,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/putsubresourceasync/202/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -604,7 +604,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/deleteasync/noheader/202/204")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -617,7 +617,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/postasync/noretry/succeeded")
         .post({ body: { ...product } });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -636,7 +636,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/postasync/retry/failed")
           .post({ body: product });
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -652,7 +652,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/postasync/retry/succeeded")
         .post({ body: { ...product } });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -673,7 +673,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/postasync/retry/canceled")
           .post({ body: product });
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -695,7 +695,7 @@ describe("LRO Rest Client", () => {
           }
         });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -724,7 +724,7 @@ describe("LRO Rest Client", () => {
           }
         });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -748,7 +748,7 @@ describe("LRO Rest Client", () => {
           }
         });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -773,7 +773,7 @@ describe("LRO Rest Client", () => {
           }
         });
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -799,7 +799,7 @@ describe("LRO Rest Client", () => {
           .put();
         assert.equal(initialResponse.status, "201");
         assert.isNotTrue(isUnexpected(initialResponse));
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
         await poller.pollUntilDone();
@@ -816,7 +816,7 @@ describe("LRO Rest Client", () => {
           .put();
         assert.equal(initialResponse.status, "201");
         assert.isNotTrue(isUnexpected(initialResponse));
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
         await poller.pollUntilDone();
@@ -833,7 +833,7 @@ describe("LRO Rest Client", () => {
           .put();
         assert.equal(initialResponse.status, "200");
         assert.isNotTrue(isUnexpected(initialResponse));
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -852,7 +852,7 @@ describe("LRO Rest Client", () => {
 
         assert.equal(initialResponse.status, "202");
         assert.isNotTrue(isUnexpected(initialResponse));
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -879,7 +879,7 @@ describe("LRO Rest Client", () => {
 
         assert.equal(initialResponse.status, "202");
         assert.isNotTrue(isUnexpected(initialResponse));
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
         await poller.pollUntilDone();
@@ -907,7 +907,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/nonretryerror/post/202/retry/400")
           .post();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -924,7 +924,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/nonretryerror/postasync/retry/400")
           .post();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -943,7 +943,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/put/201/noprovisioningstatepayload")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -956,7 +956,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/putasync/retry/nostatuspayload")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -969,7 +969,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/putasync/retry/nostatus")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -982,7 +982,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/delete/204/nolocation")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -995,7 +995,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/deleteasync/retry/nostatus")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1008,7 +1008,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/post/202/nolocation")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1021,7 +1021,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/error/postasync/retry/nopayload")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1035,7 +1035,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/put/200/invalidjson")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1051,7 +1051,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/putasync/retry/invalidheader")
           .put();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
         await poller.pollUntilDone();
@@ -1067,7 +1067,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/delete/202/retry/invalidheader")
           .delete();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1084,7 +1084,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/deleteasync/retry/invalidheader")
           .delete();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1101,7 +1101,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/deleteasync/retry/invalidjsonpolling")
           .delete();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1117,7 +1117,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/post/202/retry/invalidheader")
           .post();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1134,7 +1134,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/postasync/retry/invalidheader")
           .post();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1151,7 +1151,7 @@ describe("LRO Rest Client", () => {
           .path("/lro/error/postasync/retry/invalidjsonpolling")
           .post();
 
-        const poller = getLongRunningPoller(client, initialResponse, {
+        const poller = await getLongRunningPoller(client, initialResponse, {
           intervalInMs: 0
         });
 
@@ -1168,7 +1168,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/put/201/creating/succeeded/200")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1190,7 +1190,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/putasync/retry/succeeded")
         .put();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1211,7 +1211,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/delete/provisioning/202/accepted/200/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1232,7 +1232,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/delete/202/retry/200")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1245,7 +1245,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/deleteasync/retry/succeeded")
         .delete();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1258,7 +1258,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/post/202/retry/200")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 
@@ -1271,7 +1271,7 @@ describe("LRO Rest Client", () => {
         .path("/lro/retryerror/postasync/retry/succeeded")
         .post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 

--- a/packages/autorest.typescript/test/rlcIntegration/pagingRest.spec.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/pagingRest.spec.ts
@@ -237,15 +237,15 @@ describe("Integration tests for Paging Rest Client", () => {
           const result = firstRun
             ? initialResponse
             : await client
-              .path(
-                "/paging/multiple/fragment/{tenant}/{nextLink}",
-                tenant,
-                pageLink
-              )
-              .get({
-                queryParameters: { api_version: "1.6" },
-                skipUrlEncoding: true
-              });
+                .path(
+                  "/paging/multiple/fragment/{tenant}/{nextLink}",
+                  tenant,
+                  pageLink
+                )
+                .get({
+                  queryParameters: { api_version: "1.6" },
+                  skipUrlEncoding: true
+                });
           firstRun = false;
           if (isUnexpected(result)) {
             throw new Error("Unexpected status code");
@@ -300,8 +300,8 @@ describe("Integration tests for Paging Rest Client", () => {
           const result = firstRun
             ? initialResponse
             : await client
-              .path("/paging/multiple/nextOperationWithQueryParams")
-              .get({ queryParameters: { queryConstant: true } });
+                .path("/paging/multiple/nextOperationWithQueryParams")
+                .get({ queryParameters: { queryConstant: true } });
           firstRun = false;
           if (isUnexpected(result)) {
             throw new Error("Unexpected status code");
@@ -347,7 +347,7 @@ describe("Integration tests for Paging Rest Client", () => {
     it("succeeds and gets 10 pages", async () => {
       const initialResponse = await client.path("/paging/multiple/lro").post();
 
-      const poller = getLongRunningPoller(client, initialResponse, {
+      const poller = await getLongRunningPoller(client, initialResponse, {
         intervalInMs: 0
       });
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/operations/deploymentScripts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/operations/deploymentScripts.ts
@@ -247,7 +247,7 @@ export class DeploymentScriptsImpl implements DeploymentScripts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applicationDefinitions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applicationDefinitions.ts
@@ -195,7 +195,7 @@ export class ApplicationDefinitionsImpl implements ApplicationDefinitions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -292,7 +292,7 @@ export class ApplicationDefinitionsImpl implements ApplicationDefinitions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -411,7 +411,7 @@ export class ApplicationDefinitionsImpl implements ApplicationDefinitions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -501,7 +501,7 @@ export class ApplicationDefinitionsImpl implements ApplicationDefinitions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applications.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applications.ts
@@ -257,7 +257,7 @@ export class ApplicationsImpl implements Applications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -349,7 +349,7 @@ export class ApplicationsImpl implements Applications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -497,7 +497,7 @@ export class ApplicationsImpl implements Applications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -585,7 +585,7 @@ export class ApplicationsImpl implements Applications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/deployments.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/deployments.ts
@@ -493,7 +493,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -608,7 +608,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -785,7 +785,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -890,7 +890,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1056,7 +1056,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1171,7 +1171,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1348,7 +1348,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1456,7 +1456,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1597,7 +1597,7 @@ export class DeploymentsImpl implements Deployments {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1715,7 +1715,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1834,7 +1834,7 @@ export class DeploymentsImpl implements Deployments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1989,7 +1989,7 @@ export class DeploymentsImpl implements Deployments {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/resourceGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/resourceGroups.ts
@@ -198,7 +198,7 @@ export class ResourceGroupsImpl implements ResourceGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -318,7 +318,7 @@ export class ResourceGroupsImpl implements ResourceGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/resources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/src/operations/resources.ts
@@ -264,7 +264,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -354,7 +354,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -502,7 +502,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -625,7 +625,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -751,7 +751,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -904,7 +904,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -996,7 +996,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1095,7 +1095,7 @@ export class ResourcesImpl implements Resources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/capacityReservations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/capacityReservations.ts
@@ -212,7 +212,7 @@ export class CapacityReservationsImpl implements CapacityReservations {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -320,7 +320,7 @@ export class CapacityReservationsImpl implements CapacityReservations {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -417,7 +417,7 @@ export class CapacityReservationsImpl implements CapacityReservations {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServiceRoleInstances.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServiceRoleInstances.ts
@@ -193,7 +193,7 @@ export class CloudServiceRoleInstancesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -337,7 +337,7 @@ export class CloudServiceRoleInstancesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -426,7 +426,7 @@ export class CloudServiceRoleInstancesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -516,7 +516,7 @@ export class CloudServiceRoleInstancesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServices.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServices.ts
@@ -246,7 +246,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -337,7 +337,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -419,7 +419,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -563,7 +563,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -646,7 +646,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -729,7 +729,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -812,7 +812,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -897,7 +897,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -981,7 +981,7 @@ export class CloudServicesImpl implements CloudServices {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServicesUpdateDomain.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/cloudServicesUpdateDomain.ts
@@ -191,7 +191,7 @@ export class CloudServicesUpdateDomainImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHosts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHosts.ts
@@ -204,7 +204,7 @@ export class DedicatedHostsImpl implements DedicatedHosts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -304,7 +304,7 @@ export class DedicatedHostsImpl implements DedicatedHosts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -394,7 +394,7 @@ export class DedicatedHostsImpl implements DedicatedHosts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskAccesses.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskAccesses.ts
@@ -344,7 +344,7 @@ export class DiskAccessesImpl implements DiskAccesses {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -443,7 +443,7 @@ export class DiskAccessesImpl implements DiskAccesses {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -551,7 +551,7 @@ export class DiskAccessesImpl implements DiskAccesses {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -701,7 +701,7 @@ export class DiskAccessesImpl implements DiskAccesses {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -828,7 +828,7 @@ export class DiskAccessesImpl implements DiskAccesses {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskEncryptionSets.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskEncryptionSets.ts
@@ -342,7 +342,7 @@ export class DiskEncryptionSetsImpl implements DiskEncryptionSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -448,7 +448,7 @@ export class DiskEncryptionSetsImpl implements DiskEncryptionSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -557,7 +557,7 @@ export class DiskEncryptionSetsImpl implements DiskEncryptionSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskRestorePointOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/diskRestorePointOperations.ts
@@ -276,7 +276,7 @@ export class DiskRestorePointOperationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -380,7 +380,7 @@ export class DiskRestorePointOperationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/disks.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/disks.ts
@@ -250,7 +250,7 @@ export class DisksImpl implements Disks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -346,7 +346,7 @@ export class DisksImpl implements Disks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -454,7 +454,7 @@ export class DisksImpl implements Disks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -570,7 +570,7 @@ export class DisksImpl implements Disks {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -660,7 +660,7 @@ export class DisksImpl implements Disks {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleries.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleries.ts
@@ -245,7 +245,7 @@ export class GalleriesImpl implements Galleries {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -342,7 +342,7 @@ export class GalleriesImpl implements Galleries {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -445,7 +445,7 @@ export class GalleriesImpl implements Galleries {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryApplicationVersions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryApplicationVersions.ts
@@ -229,7 +229,7 @@ export class GalleryApplicationVersionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -351,7 +351,7 @@ export class GalleryApplicationVersionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -488,7 +488,7 @@ export class GalleryApplicationVersionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryApplications.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryApplications.ts
@@ -213,7 +213,7 @@ export class GalleryApplicationsImpl implements GalleryApplications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -325,7 +325,7 @@ export class GalleryApplicationsImpl implements GalleryApplications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -439,7 +439,7 @@ export class GalleryApplicationsImpl implements GalleryApplications {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryImageVersions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryImageVersions.ts
@@ -226,7 +226,7 @@ export class GalleryImageVersionsImpl implements GalleryImageVersions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -345,7 +345,7 @@ export class GalleryImageVersionsImpl implements GalleryImageVersions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -476,7 +476,7 @@ export class GalleryImageVersionsImpl implements GalleryImageVersions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryImages.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/galleryImages.ts
@@ -213,7 +213,7 @@ export class GalleryImagesImpl implements GalleryImages {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -325,7 +325,7 @@ export class GalleryImagesImpl implements GalleryImages {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -439,7 +439,7 @@ export class GalleryImagesImpl implements GalleryImages {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/gallerySharingProfile.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/gallerySharingProfile.ts
@@ -104,7 +104,7 @@ export class GallerySharingProfileImpl implements GallerySharingProfile {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/images.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/images.ts
@@ -245,7 +245,7 @@ export class ImagesImpl implements Images {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -337,7 +337,7 @@ export class ImagesImpl implements Images {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -422,7 +422,7 @@ export class ImagesImpl implements Images {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/logAnalytics.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/logAnalytics.ts
@@ -107,7 +107,7 @@ export class LogAnalyticsImpl implements LogAnalytics {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -199,7 +199,7 @@ export class LogAnalyticsImpl implements LogAnalytics {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/restorePointCollections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/restorePointCollections.ts
@@ -270,7 +270,7 @@ export class RestorePointCollectionsImpl implements RestorePointCollections {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/restorePoints.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/restorePoints.ts
@@ -116,7 +116,7 @@ export class RestorePointsImpl implements RestorePoints {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -212,7 +212,7 @@ export class RestorePointsImpl implements RestorePoints {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/snapshots.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/snapshots.ts
@@ -250,7 +250,7 @@ export class SnapshotsImpl implements Snapshots {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -349,7 +349,7 @@ export class SnapshotsImpl implements Snapshots {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -457,7 +457,7 @@ export class SnapshotsImpl implements Snapshots {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -579,7 +579,7 @@ export class SnapshotsImpl implements Snapshots {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -669,7 +669,7 @@ export class SnapshotsImpl implements Snapshots {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineExtensions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineExtensions.ts
@@ -120,7 +120,7 @@ export class VirtualMachineExtensionsImpl implements VirtualMachineExtensions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -226,7 +226,7 @@ export class VirtualMachineExtensionsImpl implements VirtualMachineExtensions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -316,7 +316,7 @@ export class VirtualMachineExtensionsImpl implements VirtualMachineExtensions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineRunCommands.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineRunCommands.ts
@@ -301,7 +301,7 @@ export class VirtualMachineRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -401,7 +401,7 @@ export class VirtualMachineRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -491,7 +491,7 @@ export class VirtualMachineRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetExtensions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetExtensions.ts
@@ -202,7 +202,7 @@ export class VirtualMachineScaleSetExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -308,7 +308,7 @@ export class VirtualMachineScaleSetExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -398,7 +398,7 @@ export class VirtualMachineScaleSetExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetRollingUpgrades.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetRollingUpgrades.ts
@@ -97,7 +97,7 @@ export class VirtualMachineScaleSetRollingUpgradesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -181,7 +181,7 @@ export class VirtualMachineScaleSetRollingUpgradesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -267,7 +267,7 @@ export class VirtualMachineScaleSetRollingUpgradesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMExtensions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMExtensions.ts
@@ -124,7 +124,7 @@ export class VirtualMachineScaleSetVMExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -236,7 +236,7 @@ export class VirtualMachineScaleSetVMExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -337,7 +337,7 @@ export class VirtualMachineScaleSetVMExtensionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMRunCommands.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMRunCommands.ts
@@ -222,7 +222,7 @@ export class VirtualMachineScaleSetVMRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -334,7 +334,7 @@ export class VirtualMachineScaleSetVMRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -435,7 +435,7 @@ export class VirtualMachineScaleSetVMRunCommandsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMs.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMs.ts
@@ -207,7 +207,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -295,7 +295,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -385,7 +385,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -490,7 +490,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -580,7 +580,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -724,7 +724,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -813,7 +813,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -900,7 +900,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -988,7 +988,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1095,7 +1095,7 @@ export class VirtualMachineScaleSetVMsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1218,7 +1218,7 @@ export class VirtualMachineScaleSetVMsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSets.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSets.ts
@@ -514,7 +514,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -609,7 +609,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -694,7 +694,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -795,7 +795,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -881,7 +881,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1047,7 +1047,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1131,7 +1131,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1213,7 +1213,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1296,7 +1296,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1382,7 +1382,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1469,7 +1469,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1556,7 +1556,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1641,7 +1641,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1767,7 +1767,7 @@ export class VirtualMachineScaleSetsImpl implements VirtualMachineScaleSets {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachines.ts
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/src/operations/virtualMachines.ts
@@ -413,7 +413,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -510,7 +510,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -606,7 +606,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -691,7 +691,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -804,7 +804,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -888,7 +888,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1038,7 +1038,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1117,7 +1117,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1195,7 +1195,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1273,7 +1273,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1351,7 +1351,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1429,7 +1429,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1524,7 +1524,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1632,7 +1632,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1725,7 +1725,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1821,7 +1821,7 @@ export class VirtualMachinesImpl implements VirtualMachines {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraClusters.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraClusters.ts
@@ -250,7 +250,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -439,7 +439,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -534,7 +534,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -621,7 +621,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -707,7 +707,7 @@ export class CassandraClustersImpl implements CassandraClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraDataCenters.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraDataCenters.ts
@@ -199,7 +199,7 @@ export class CassandraDataCentersImpl implements CassandraDataCenters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -297,7 +297,7 @@ export class CassandraDataCentersImpl implements CassandraDataCenters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -398,7 +398,7 @@ export class CassandraDataCentersImpl implements CassandraDataCenters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraResources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraResources.ts
@@ -324,7 +324,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -415,7 +415,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -543,7 +543,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -646,7 +646,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -745,7 +745,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -894,7 +894,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -996,7 +996,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1128,7 +1128,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1240,7 +1240,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1350,7 +1350,7 @@ export class CassandraResourcesImpl implements CassandraResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/databaseAccounts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/databaseAccounts.ts
@@ -456,7 +456,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -552,7 +552,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -638,7 +638,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -725,7 +725,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -879,7 +879,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -971,7 +971,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1092,7 +1092,7 @@ export class DatabaseAccountsImpl implements DatabaseAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/gremlinResources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/gremlinResources.ts
@@ -324,7 +324,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -415,7 +415,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -539,7 +539,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -638,7 +638,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -737,7 +737,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -883,7 +883,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -984,7 +984,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1116,7 +1116,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1226,7 +1226,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1336,7 +1336,7 @@ export class GremlinResourcesImpl implements GremlinResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/mongoDBResources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/mongoDBResources.ts
@@ -327,7 +327,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -418,7 +418,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -542,7 +542,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -641,7 +641,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -740,7 +740,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -887,7 +887,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -989,7 +989,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1121,7 +1121,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1235,7 +1235,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1345,7 +1345,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1461,7 +1461,7 @@ export class MongoDBResourcesImpl implements MongoDBResources {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/notebookWorkspaces.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/notebookWorkspaces.ts
@@ -228,7 +228,7 @@ export class NotebookWorkspacesImpl implements NotebookWorkspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -319,7 +319,7 @@ export class NotebookWorkspacesImpl implements NotebookWorkspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -425,7 +425,7 @@ export class NotebookWorkspacesImpl implements NotebookWorkspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -512,7 +512,7 @@ export class NotebookWorkspacesImpl implements NotebookWorkspaces {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/privateEndpointConnections.ts
@@ -227,7 +227,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -322,7 +322,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/sqlResources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/sqlResources.ts
@@ -748,7 +748,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -838,7 +838,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -962,7 +962,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1061,7 +1061,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1156,7 +1156,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1302,7 +1302,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1403,7 +1403,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1534,7 +1534,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1644,7 +1644,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1750,7 +1750,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1914,7 +1914,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2022,7 +2022,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2189,7 +2189,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2297,7 +2297,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2463,7 +2463,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2570,7 +2570,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2699,7 +2699,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2790,7 +2790,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2930,7 +2930,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3021,7 +3021,7 @@ export class SqlResourcesImpl implements SqlResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3145,7 +3145,7 @@ export class SqlResourcesImpl implements SqlResources {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/tableResources.ts
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/src/operations/tableResources.ts
@@ -227,7 +227,7 @@ export class TableResourcesImpl implements TableResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -317,7 +317,7 @@ export class TableResourcesImpl implements TableResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -441,7 +441,7 @@ export class TableResourcesImpl implements TableResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -540,7 +540,7 @@ export class TableResourcesImpl implements TableResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -635,7 +635,7 @@ export class TableResourcesImpl implements TableResources {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/managedHsms.ts
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/managedHsms.ts
@@ -306,7 +306,7 @@ export class ManagedHsmsImpl implements ManagedHsms {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -401,7 +401,7 @@ export class ManagedHsmsImpl implements ManagedHsms {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -486,7 +486,7 @@ export class ManagedHsmsImpl implements ManagedHsms {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -640,7 +640,7 @@ export class ManagedHsmsImpl implements ManagedHsms {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/mhsmPrivateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/mhsmPrivateEndpointConnections.ts
@@ -260,7 +260,7 @@ export class MhsmPrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/privateEndpointConnections.ts
@@ -255,7 +255,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/vaults.ts
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/src/operations/vaults.ts
@@ -374,7 +374,7 @@ export class VaultsImpl implements Vaults {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -592,7 +592,7 @@ export class VaultsImpl implements Vaults {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
@@ -944,7 +944,7 @@ export class NetworkManagementClient extends coreClient.ServiceClient {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1010,7 +1010,7 @@ export class NetworkManagementClient extends coreClient.ServiceClient {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1123,7 +1123,7 @@ export class NetworkManagementClient extends coreClient.ServiceClient {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1255,7 +1255,7 @@ export class NetworkManagementClient extends coreClient.ServiceClient {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationGatewayPrivateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationGatewayPrivateEndpointConnections.ts
@@ -197,7 +197,7 @@ export class ApplicationGatewayPrivateEndpointConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -304,7 +304,7 @@ export class ApplicationGatewayPrivateEndpointConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationGateways.ts
@@ -314,7 +314,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -424,7 +424,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -554,7 +554,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -637,7 +637,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -728,7 +728,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -827,7 +827,7 @@ export class ApplicationGatewaysImpl implements ApplicationGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationSecurityGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/applicationSecurityGroups.ts
@@ -229,7 +229,7 @@ export class ApplicationSecurityGroupsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -344,7 +344,7 @@ export class ApplicationSecurityGroupsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/azureFirewalls.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/azureFirewalls.ts
@@ -228,7 +228,7 @@ export class AzureFirewallsImpl implements AzureFirewalls {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class AzureFirewallsImpl implements AzureFirewalls {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -434,7 +434,7 @@ export class AzureFirewallsImpl implements AzureFirewalls {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/bastionHosts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/bastionHosts.ts
@@ -235,7 +235,7 @@ export class BastionHostsImpl implements BastionHosts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -345,7 +345,7 @@ export class BastionHostsImpl implements BastionHosts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -441,7 +441,7 @@ export class BastionHostsImpl implements BastionHosts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/connectionMonitors.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/connectionMonitors.ts
@@ -190,7 +190,7 @@ export class ConnectionMonitorsImpl implements ConnectionMonitors {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -305,7 +305,7 @@ export class ConnectionMonitorsImpl implements ConnectionMonitors {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -425,7 +425,7 @@ export class ConnectionMonitorsImpl implements ConnectionMonitors {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -518,7 +518,7 @@ export class ConnectionMonitorsImpl implements ConnectionMonitors {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -619,7 +619,7 @@ export class ConnectionMonitorsImpl implements ConnectionMonitors {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/customIPPrefixes.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/customIPPrefixes.ts
@@ -228,7 +228,7 @@ export class CustomIPPrefixesImpl implements CustomIPPrefixes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class CustomIPPrefixesImpl implements CustomIPPrefixes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ddosCustomPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ddosCustomPolicies.ts
@@ -101,7 +101,7 @@ export class DdosCustomPoliciesImpl implements DdosCustomPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -211,7 +211,7 @@ export class DdosCustomPoliciesImpl implements DdosCustomPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ddosProtectionPlans.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ddosProtectionPlans.ts
@@ -235,7 +235,7 @@ export class DdosProtectionPlansImpl implements DdosProtectionPlans {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -345,7 +345,7 @@ export class DdosProtectionPlansImpl implements DdosProtectionPlans {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/dscpConfigurationOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/dscpConfigurationOperations.ts
@@ -236,7 +236,7 @@ export class DscpConfigurationOperationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -322,7 +322,7 @@ export class DscpConfigurationOperationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitAuthorizations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitAuthorizations.ts
@@ -184,7 +184,7 @@ export class ExpressRouteCircuitAuthorizationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -308,7 +308,7 @@ export class ExpressRouteCircuitAuthorizationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitConnections.ts
@@ -209,7 +209,7 @@ export class ExpressRouteCircuitConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -341,7 +341,7 @@ export class ExpressRouteCircuitConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitPeerings.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitPeerings.ts
@@ -184,7 +184,7 @@ export class ExpressRouteCircuitPeeringsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -308,7 +308,7 @@ export class ExpressRouteCircuitPeeringsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuits.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuits.ts
@@ -238,7 +238,7 @@ export class ExpressRouteCircuitsImpl implements ExpressRouteCircuits {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -348,7 +348,7 @@ export class ExpressRouteCircuitsImpl implements ExpressRouteCircuits {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -472,7 +472,7 @@ export class ExpressRouteCircuitsImpl implements ExpressRouteCircuits {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -581,7 +581,7 @@ export class ExpressRouteCircuitsImpl implements ExpressRouteCircuits {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -690,7 +690,7 @@ export class ExpressRouteCircuitsImpl implements ExpressRouteCircuits {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteConnections.ts
@@ -119,7 +119,7 @@ export class ExpressRouteConnectionsImpl implements ExpressRouteConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -235,7 +235,7 @@ export class ExpressRouteConnectionsImpl implements ExpressRouteConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnectionPeerings.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnectionPeerings.ts
@@ -209,7 +209,7 @@ export class ExpressRouteCrossConnectionPeeringsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -333,7 +333,7 @@ export class ExpressRouteCrossConnectionPeeringsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnections.ts
@@ -293,7 +293,7 @@ export class ExpressRouteCrossConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -422,7 +422,7 @@ export class ExpressRouteCrossConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -532,7 +532,7 @@ export class ExpressRouteCrossConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -640,7 +640,7 @@ export class ExpressRouteCrossConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRouteGateways.ts
@@ -149,7 +149,7 @@ export class ExpressRouteGatewaysImpl implements ExpressRouteGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -252,7 +252,7 @@ export class ExpressRouteGatewaysImpl implements ExpressRouteGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -357,7 +357,7 @@ export class ExpressRouteGatewaysImpl implements ExpressRouteGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRoutePorts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/expressRoutePorts.ts
@@ -238,7 +238,7 @@ export class ExpressRoutePortsImpl implements ExpressRoutePorts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -348,7 +348,7 @@ export class ExpressRoutePortsImpl implements ExpressRoutePorts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/firewallPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/firewallPolicies.ts
@@ -225,7 +225,7 @@ export class FirewallPoliciesImpl implements FirewallPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -335,7 +335,7 @@ export class FirewallPoliciesImpl implements FirewallPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/firewallPolicyRuleCollectionGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/firewallPolicyRuleCollectionGroups.ts
@@ -193,7 +193,7 @@ export class FirewallPolicyRuleCollectionGroupsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -322,7 +322,7 @@ export class FirewallPolicyRuleCollectionGroupsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/flowLogs.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/flowLogs.ts
@@ -206,7 +206,7 @@ export class FlowLogsImpl implements FlowLogs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class FlowLogsImpl implements FlowLogs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/hubRouteTables.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/hubRouteTables.ts
@@ -199,7 +199,7 @@ export class HubRouteTablesImpl implements HubRouteTables {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -309,7 +309,7 @@ export class HubRouteTablesImpl implements HubRouteTables {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/hubVirtualNetworkConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/hubVirtualNetworkConnections.ts
@@ -201,7 +201,7 @@ export class HubVirtualNetworkConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -293,7 +293,7 @@ export class HubVirtualNetworkConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/inboundNatRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/inboundNatRules.ts
@@ -209,7 +209,7 @@ export class InboundNatRulesImpl implements InboundNatRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -333,7 +333,7 @@ export class InboundNatRulesImpl implements InboundNatRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/inboundSecurityRuleOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/inboundSecurityRuleOperations.ts
@@ -115,7 +115,7 @@ export class InboundSecurityRuleOperationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ipAllocations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ipAllocations.ts
@@ -235,7 +235,7 @@ export class IpAllocationsImpl implements IpAllocations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -345,7 +345,7 @@ export class IpAllocationsImpl implements IpAllocations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ipGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/ipGroups.ts
@@ -262,7 +262,7 @@ export class IpGroupsImpl implements IpGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -367,7 +367,7 @@ export class IpGroupsImpl implements IpGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/loadBalancerBackendAddressPools.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/loadBalancerBackendAddressPools.ts
@@ -241,7 +241,7 @@ export class LoadBalancerBackendAddressPoolsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class LoadBalancerBackendAddressPoolsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/loadBalancers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/loadBalancers.ts
@@ -233,7 +233,7 @@ export class LoadBalancersImpl implements LoadBalancers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class LoadBalancersImpl implements LoadBalancers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -473,7 +473,7 @@ export class LoadBalancersImpl implements LoadBalancers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -574,7 +574,7 @@ export class LoadBalancersImpl implements LoadBalancers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/localNetworkGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/localNetworkGateways.ts
@@ -180,7 +180,7 @@ export class LocalNetworkGatewaysImpl implements LocalNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -283,7 +283,7 @@ export class LocalNetworkGatewaysImpl implements LocalNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/natGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/natGateways.ts
@@ -228,7 +228,7 @@ export class NatGatewaysImpl implements NatGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class NatGatewaysImpl implements NatGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/natRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/natRules.ts
@@ -227,7 +227,7 @@ export class NatRulesImpl implements NatRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -319,7 +319,7 @@ export class NatRulesImpl implements NatRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkInterfaceTapConfigurations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkInterfaceTapConfigurations.ts
@@ -197,7 +197,7 @@ export class NetworkInterfaceTapConfigurationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -326,7 +326,7 @@ export class NetworkInterfaceTapConfigurationsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkInterfaces.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkInterfaces.ts
@@ -780,7 +780,7 @@ export class NetworkInterfacesImpl implements NetworkInterfaces {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -890,7 +890,7 @@ export class NetworkInterfacesImpl implements NetworkInterfaces {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1028,7 +1028,7 @@ export class NetworkInterfacesImpl implements NetworkInterfaces {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1123,7 +1123,7 @@ export class NetworkInterfacesImpl implements NetworkInterfaces {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkProfiles.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkProfiles.ts
@@ -228,7 +228,7 @@ export class NetworkProfilesImpl implements NetworkProfiles {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkSecurityGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkSecurityGroups.ts
@@ -228,7 +228,7 @@ export class NetworkSecurityGroupsImpl implements NetworkSecurityGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -343,7 +343,7 @@ export class NetworkSecurityGroupsImpl implements NetworkSecurityGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkVirtualAppliances.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkVirtualAppliances.ts
@@ -235,7 +235,7 @@ export class NetworkVirtualAppliancesImpl implements NetworkVirtualAppliances {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -369,7 +369,7 @@ export class NetworkVirtualAppliancesImpl implements NetworkVirtualAppliances {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkWatchers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/networkWatchers.ts
@@ -265,7 +265,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -421,7 +421,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -517,7 +517,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -613,7 +613,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -709,7 +709,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -805,7 +805,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -901,7 +901,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -998,7 +998,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1096,7 +1096,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1194,7 +1194,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1292,7 +1292,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1393,7 +1393,7 @@ export class NetworkWatchersImpl implements NetworkWatchers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/p2SVpnGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/p2SVpnGateways.ts
@@ -280,7 +280,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -382,7 +382,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -468,7 +468,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -584,7 +584,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -677,7 +677,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -772,7 +772,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -867,7 +867,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -956,7 +956,7 @@ export class P2SVpnGatewaysImpl implements P2SVpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/packetCaptures.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/packetCaptures.ts
@@ -186,7 +186,7 @@ export class PacketCapturesImpl implements PacketCaptures {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -301,7 +301,7 @@ export class PacketCapturesImpl implements PacketCaptures {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -394,7 +394,7 @@ export class PacketCapturesImpl implements PacketCaptures {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -495,7 +495,7 @@ export class PacketCapturesImpl implements PacketCaptures {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateDnsZoneGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateDnsZoneGroups.ts
@@ -196,7 +196,7 @@ export class PrivateDnsZoneGroupsImpl implements PrivateDnsZoneGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -324,7 +324,7 @@ export class PrivateDnsZoneGroupsImpl implements PrivateDnsZoneGroups {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateEndpoints.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateEndpoints.ts
@@ -225,7 +225,7 @@ export class PrivateEndpointsImpl implements PrivateEndpoints {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -335,7 +335,7 @@ export class PrivateEndpointsImpl implements PrivateEndpoints {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateLinkServices.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/privateLinkServices.ts
@@ -494,7 +494,7 @@ export class PrivateLinkServicesImpl implements PrivateLinkServices {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -604,7 +604,7 @@ export class PrivateLinkServicesImpl implements PrivateLinkServices {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -761,7 +761,7 @@ export class PrivateLinkServicesImpl implements PrivateLinkServices {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -876,7 +876,7 @@ export class PrivateLinkServicesImpl implements PrivateLinkServices {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -973,7 +973,7 @@ export class PrivateLinkServicesImpl implements PrivateLinkServices {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/publicIPAddresses.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/publicIPAddresses.ts
@@ -723,7 +723,7 @@ export class PublicIPAddressesImpl implements PublicIPAddresses {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -833,7 +833,7 @@ export class PublicIPAddressesImpl implements PublicIPAddresses {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/publicIPPrefixes.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/publicIPPrefixes.ts
@@ -228,7 +228,7 @@ export class PublicIPPrefixesImpl implements PublicIPPrefixes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class PublicIPPrefixesImpl implements PublicIPPrefixes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeFilterRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeFilterRules.ts
@@ -191,7 +191,7 @@ export class RouteFilterRulesImpl implements RouteFilterRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -315,7 +315,7 @@ export class RouteFilterRulesImpl implements RouteFilterRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeFilters.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeFilters.ts
@@ -235,7 +235,7 @@ export class RouteFiltersImpl implements RouteFilters {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -350,7 +350,7 @@ export class RouteFiltersImpl implements RouteFilters {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeTables.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routeTables.ts
@@ -228,7 +228,7 @@ export class RouteTablesImpl implements RouteTables {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class RouteTablesImpl implements RouteTables {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routes.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routes.ts
@@ -183,7 +183,7 @@ export class RoutesImpl implements Routes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -306,7 +306,7 @@ export class RoutesImpl implements Routes {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routingIntentOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/routingIntentOperations.ts
@@ -199,7 +199,7 @@ export class RoutingIntentOperationsImpl implements RoutingIntentOperations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -309,7 +309,7 @@ export class RoutingIntentOperationsImpl implements RoutingIntentOperations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/securityPartnerProviders.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/securityPartnerProviders.ts
@@ -235,7 +235,7 @@ export class SecurityPartnerProvidersImpl implements SecurityPartnerProviders {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -350,7 +350,7 @@ export class SecurityPartnerProvidersImpl implements SecurityPartnerProviders {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/securityRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/securityRules.ts
@@ -196,7 +196,7 @@ export class SecurityRulesImpl implements SecurityRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -325,7 +325,7 @@ export class SecurityRulesImpl implements SecurityRules {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicies.ts
@@ -235,7 +235,7 @@ export class ServiceEndpointPoliciesImpl implements ServiceEndpointPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -350,7 +350,7 @@ export class ServiceEndpointPoliciesImpl implements ServiceEndpointPolicies {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicyDefinitions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicyDefinitions.ts
@@ -197,7 +197,7 @@ export class ServiceEndpointPolicyDefinitionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -326,7 +326,7 @@ export class ServiceEndpointPolicyDefinitionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/subnets.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/subnets.ts
@@ -191,7 +191,7 @@ export class SubnetsImpl implements Subnets {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -314,7 +314,7 @@ export class SubnetsImpl implements Subnets {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -414,7 +414,7 @@ export class SubnetsImpl implements Subnets {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -515,7 +515,7 @@ export class SubnetsImpl implements Subnets {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualApplianceSites.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualApplianceSites.ts
@@ -196,7 +196,7 @@ export class VirtualApplianceSitesImpl implements VirtualApplianceSites {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -320,7 +320,7 @@ export class VirtualApplianceSitesImpl implements VirtualApplianceSites {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubBgpConnection.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubBgpConnection.ts
@@ -136,7 +136,7 @@ export class VirtualHubBgpConnectionImpl implements VirtualHubBgpConnection {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -228,7 +228,7 @@ export class VirtualHubBgpConnectionImpl implements VirtualHubBgpConnection {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubBgpConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubBgpConnections.ts
@@ -207,7 +207,7 @@ export class VirtualHubBgpConnectionsImpl implements VirtualHubBgpConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -303,7 +303,7 @@ export class VirtualHubBgpConnectionsImpl implements VirtualHubBgpConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubIpConfiguration.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubIpConfiguration.ts
@@ -220,7 +220,7 @@ export class VirtualHubIpConfigurationImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -312,7 +312,7 @@ export class VirtualHubIpConfigurationImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubRouteTableV2S.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubRouteTableV2S.ts
@@ -220,7 +220,7 @@ export class VirtualHubRouteTableV2SImpl implements VirtualHubRouteTableV2S {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -313,7 +313,7 @@ export class VirtualHubRouteTableV2SImpl implements VirtualHubRouteTableV2S {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubs.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualHubs.ts
@@ -268,7 +268,7 @@ export class VirtualHubsImpl implements VirtualHubs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -373,7 +373,7 @@ export class VirtualHubsImpl implements VirtualHubs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -481,7 +481,7 @@ export class VirtualHubsImpl implements VirtualHubs {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayConnections.ts
@@ -204,7 +204,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -308,7 +308,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -406,7 +406,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -510,7 +510,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -652,7 +652,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -752,7 +752,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -851,7 +851,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -947,7 +947,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1031,7 +1031,7 @@ export class VirtualNetworkGatewayConnectionsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayNatRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayNatRules.ts
@@ -228,7 +228,7 @@ export class VirtualNetworkGatewayNatRulesImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -325,7 +325,7 @@ export class VirtualNetworkGatewayNatRulesImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGateways.ts
@@ -309,7 +309,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -412,7 +412,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -510,7 +510,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -636,7 +636,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -719,7 +719,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -819,7 +819,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -924,7 +924,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1021,7 +1021,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1113,7 +1113,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1222,7 +1222,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1317,7 +1317,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1421,7 +1421,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1519,7 +1519,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1637,7 +1637,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1736,7 +1736,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1834,7 +1834,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1920,7 +1920,7 @@ export class VirtualNetworkGatewaysImpl implements VirtualNetworkGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkPeerings.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkPeerings.ts
@@ -192,7 +192,7 @@ export class VirtualNetworkPeeringsImpl implements VirtualNetworkPeerings {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -321,7 +321,7 @@ export class VirtualNetworkPeeringsImpl implements VirtualNetworkPeerings {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkTaps.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkTaps.ts
@@ -235,7 +235,7 @@ export class VirtualNetworkTapsImpl implements VirtualNetworkTaps {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -341,7 +341,7 @@ export class VirtualNetworkTapsImpl implements VirtualNetworkTaps {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworks.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualNetworks.ts
@@ -319,7 +319,7 @@ export class VirtualNetworksImpl implements VirtualNetworks {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -429,7 +429,7 @@ export class VirtualNetworksImpl implements VirtualNetworks {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualRouterPeerings.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualRouterPeerings.ts
@@ -187,7 +187,7 @@ export class VirtualRouterPeeringsImpl implements VirtualRouterPeerings {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -310,7 +310,7 @@ export class VirtualRouterPeeringsImpl implements VirtualRouterPeerings {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualRouters.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualRouters.ts
@@ -232,7 +232,7 @@ export class VirtualRoutersImpl implements VirtualRouters {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -342,7 +342,7 @@ export class VirtualRoutersImpl implements VirtualRouters {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualWans.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/virtualWans.ts
@@ -262,7 +262,7 @@ export class VirtualWansImpl implements VirtualWans {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -367,7 +367,7 @@ export class VirtualWansImpl implements VirtualWans {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnConnections.ts
@@ -231,7 +231,7 @@ export class VpnConnectionsImpl implements VpnConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -323,7 +323,7 @@ export class VpnConnectionsImpl implements VpnConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -419,7 +419,7 @@ export class VpnConnectionsImpl implements VpnConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -515,7 +515,7 @@ export class VpnConnectionsImpl implements VpnConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnGateways.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnGateways.ts
@@ -268,7 +268,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -364,7 +364,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -450,7 +450,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -541,7 +541,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -632,7 +632,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -723,7 +723,7 @@ export class VpnGatewaysImpl implements VpnGateways {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnLinkConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnLinkConnections.ts
@@ -206,7 +206,7 @@ export class VpnLinkConnectionsImpl implements VpnLinkConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -313,7 +313,7 @@ export class VpnLinkConnectionsImpl implements VpnLinkConnections {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurations.ts
@@ -269,7 +269,7 @@ export class VpnServerConfigurationsImpl implements VpnServerConfigurations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -381,7 +381,7 @@ export class VpnServerConfigurationsImpl implements VpnServerConfigurations {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurationsAssociatedWithVirtualWan.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurationsAssociatedWithVirtualWan.ts
@@ -107,7 +107,7 @@ export class VpnServerConfigurationsAssociatedWithVirtualWanImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnSites.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnSites.ts
@@ -262,7 +262,7 @@ export class VpnSitesImpl implements VpnSites {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -367,7 +367,7 @@ export class VpnSitesImpl implements VpnSites {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnSitesConfiguration.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/vpnSitesConfiguration.ts
@@ -96,7 +96,7 @@ export class VpnSitesConfigurationImpl implements VpnSitesConfiguration {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/webApplicationFirewallPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/src/operations/webApplicationFirewallPolicies.ts
@@ -287,7 +287,7 @@ export class WebApplicationFirewallPoliciesImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/backupShortTermRetentionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/backupShortTermRetentionPolicies.ts
@@ -245,7 +245,7 @@ export class BackupShortTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -359,7 +359,7 @@ export class BackupShortTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databaseExtensionsOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databaseExtensionsOperations.ts
@@ -242,7 +242,7 @@ export class DatabaseExtensionsOperationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessmentScans.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessmentScans.ts
@@ -223,7 +223,7 @@ export class DatabaseVulnerabilityAssessmentScansImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databases.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/databases.ts
@@ -652,7 +652,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -744,7 +744,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -849,7 +849,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -961,7 +961,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1076,7 +1076,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1173,7 +1173,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1262,7 +1262,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1389,7 +1389,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1497,7 +1497,7 @@ export class DatabasesImpl implements Databases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/deletedServers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/deletedServers.ts
@@ -276,7 +276,7 @@ export class DeletedServersImpl implements DeletedServers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/elasticPools.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/elasticPools.ts
@@ -452,7 +452,7 @@ export class ElasticPoolsImpl implements ElasticPools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -544,7 +544,7 @@ export class ElasticPoolsImpl implements ElasticPools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -649,7 +649,7 @@ export class ElasticPoolsImpl implements ElasticPools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -741,7 +741,7 @@ export class ElasticPoolsImpl implements ElasticPools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/encryptionProtectors.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/encryptionProtectors.ts
@@ -243,7 +243,7 @@ export class EncryptionProtectorsImpl implements EncryptionProtectors {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -335,7 +335,7 @@ export class EncryptionProtectorsImpl implements EncryptionProtectors {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/extendedServerBlobAuditingPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/extendedServerBlobAuditingPolicies.ts
@@ -214,7 +214,7 @@ export class ExtendedServerBlobAuditingPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/failoverGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/failoverGroups.ts
@@ -231,7 +231,7 @@ export class FailoverGroupsImpl implements FailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -323,7 +323,7 @@ export class FailoverGroupsImpl implements FailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -428,7 +428,7 @@ export class FailoverGroupsImpl implements FailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -546,7 +546,7 @@ export class FailoverGroupsImpl implements FailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -643,7 +643,7 @@ export class FailoverGroupsImpl implements FailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/instanceFailoverGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/instanceFailoverGroups.ts
@@ -232,7 +232,7 @@ export class InstanceFailoverGroupsImpl implements InstanceFailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -324,7 +324,7 @@ export class InstanceFailoverGroupsImpl implements InstanceFailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -439,7 +439,7 @@ export class InstanceFailoverGroupsImpl implements InstanceFailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -537,7 +537,7 @@ export class InstanceFailoverGroupsImpl implements InstanceFailoverGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/instancePools.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/instancePools.ts
@@ -264,7 +264,7 @@ export class InstancePoolsImpl implements InstancePools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -351,7 +351,7 @@ export class InstancePoolsImpl implements InstancePools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -445,7 +445,7 @@ export class InstancePoolsImpl implements InstancePools {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/jobAgents.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/jobAgents.ts
@@ -245,7 +245,7 @@ export class JobAgentsImpl implements JobAgents {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -337,7 +337,7 @@ export class JobAgentsImpl implements JobAgents {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -442,7 +442,7 @@ export class JobAgentsImpl implements JobAgents {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/jobExecutions.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/jobExecutions.ts
@@ -371,7 +371,7 @@ export class JobExecutionsImpl implements JobExecutions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -535,7 +535,7 @@ export class JobExecutionsImpl implements JobExecutions {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/ledgerDigestUploadsOperations.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/ledgerDigestUploadsOperations.ts
@@ -251,7 +251,7 @@ export class LedgerDigestUploadsOperationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -383,7 +383,7 @@ export class LedgerDigestUploadsOperationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionBackups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionBackups.ts
@@ -680,7 +680,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -792,7 +792,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -920,7 +920,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1089,7 +1089,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1209,7 +1209,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1349,7 +1349,7 @@ export class LongTermRetentionBackupsImpl implements LongTermRetentionBackups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionManagedInstanceBackups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionManagedInstanceBackups.ts
@@ -681,7 +681,7 @@ export class LongTermRetentionManagedInstanceBackupsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -867,7 +867,7 @@ export class LongTermRetentionManagedInstanceBackupsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/longTermRetentionPolicies.ts
@@ -243,7 +243,7 @@ export class LongTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedBackupShortTermRetentionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedBackupShortTermRetentionPolicies.ts
@@ -255,7 +255,7 @@ export class ManagedBackupShortTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -369,7 +369,7 @@ export class ManagedBackupShortTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessmentScans.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessmentScans.ts
@@ -223,7 +223,7 @@ export class ManagedDatabaseVulnerabilityAssessmentScansImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedDatabases.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedDatabases.ts
@@ -340,7 +340,7 @@ export class ManagedDatabasesImpl implements ManagedDatabases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -432,7 +432,7 @@ export class ManagedDatabasesImpl implements ManagedDatabases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -537,7 +537,7 @@ export class ManagedDatabasesImpl implements ManagedDatabases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -637,7 +637,7 @@ export class ManagedDatabasesImpl implements ManagedDatabases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAdministrators.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAdministrators.ts
@@ -248,7 +248,7 @@ export class ManagedInstanceAdministratorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -345,7 +345,7 @@ export class ManagedInstanceAdministratorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAzureADOnlyAuthentications.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAzureADOnlyAuthentications.ts
@@ -236,7 +236,7 @@ export class ManagedInstanceAzureADOnlyAuthenticationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -335,7 +335,7 @@ export class ManagedInstanceAzureADOnlyAuthenticationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceEncryptionProtectors.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceEncryptionProtectors.ts
@@ -199,7 +199,7 @@ export class ManagedInstanceEncryptionProtectorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -347,7 +347,7 @@ export class ManagedInstanceEncryptionProtectorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceKeys.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceKeys.ts
@@ -246,7 +246,7 @@ export class ManagedInstanceKeysImpl implements ManagedInstanceKeys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -338,7 +338,7 @@ export class ManagedInstanceKeysImpl implements ManagedInstanceKeys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceLongTermRetentionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceLongTermRetentionPolicies.ts
@@ -253,7 +253,7 @@ export class ManagedInstanceLongTermRetentionPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstancePrivateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstancePrivateEndpointConnections.ts
@@ -238,7 +238,7 @@ export class ManagedInstancePrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -335,7 +335,7 @@ export class ManagedInstancePrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceTdeCertificates.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceTdeCertificates.ts
@@ -97,7 +97,7 @@ export class ManagedInstanceTdeCertificatesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstances.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedInstances.ts
@@ -488,7 +488,7 @@ export class ManagedInstancesImpl implements ManagedInstances {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -575,7 +575,7 @@ export class ManagedInstancesImpl implements ManagedInstances {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -669,7 +669,7 @@ export class ManagedInstancesImpl implements ManagedInstances {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -774,7 +774,7 @@ export class ManagedInstancesImpl implements ManagedInstances {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedRestorableDroppedDatabaseBackupShortTermRetentionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedRestorableDroppedDatabaseBackupShortTermRetentionPolicies.ts
@@ -257,7 +257,7 @@ export class ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesImp
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -377,7 +377,7 @@ export class ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesImp
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedServerSecurityAlertPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/managedServerSecurityAlertPolicies.ts
@@ -234,7 +234,7 @@ export class ManagedServerSecurityAlertPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/outboundFirewallRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/outboundFirewallRules.ts
@@ -224,7 +224,7 @@ export class OutboundFirewallRulesImpl implements OutboundFirewallRules {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -316,7 +316,7 @@ export class OutboundFirewallRulesImpl implements OutboundFirewallRules {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/privateEndpointConnections.ts
@@ -225,7 +225,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -322,7 +322,7 @@ export class PrivateEndpointConnectionsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/replicationLinks.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/replicationLinks.ts
@@ -312,7 +312,7 @@ export class ReplicationLinksImpl implements ReplicationLinks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -407,7 +407,7 @@ export class ReplicationLinksImpl implements ReplicationLinks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -511,7 +511,7 @@ export class ReplicationLinksImpl implements ReplicationLinks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/restorePoints.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/restorePoints.ts
@@ -238,7 +238,7 @@ export class RestorePointsImpl implements RestorePoints {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADAdministrators.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADAdministrators.ts
@@ -226,7 +226,7 @@ export class ServerAzureADAdministratorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -318,7 +318,7 @@ export class ServerAzureADAdministratorsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADOnlyAuthentications.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADOnlyAuthentications.ts
@@ -228,7 +228,7 @@ export class ServerAzureADOnlyAuthenticationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -322,7 +322,7 @@ export class ServerAzureADOnlyAuthenticationsImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverBlobAuditingPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverBlobAuditingPolicies.ts
@@ -214,7 +214,7 @@ export class ServerBlobAuditingPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverCommunicationLinks.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverCommunicationLinks.ts
@@ -223,7 +223,7 @@ export class ServerCommunicationLinksImpl implements ServerCommunicationLinks {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverConnectionPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverConnectionPolicies.ts
@@ -224,7 +224,7 @@ export class ServerConnectionPoliciesImpl implements ServerConnectionPolicies {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverDevOpsAuditSettings.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverDevOpsAuditSettings.ts
@@ -227,7 +227,7 @@ export class ServerDevOpsAuditSettingsImpl
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "azure-async-operation"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverDnsAliases.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverDnsAliases.ts
@@ -219,7 +219,7 @@ export class ServerDnsAliasesImpl implements ServerDnsAliases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -308,7 +308,7 @@ export class ServerDnsAliasesImpl implements ServerDnsAliases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -431,7 +431,7 @@ export class ServerDnsAliasesImpl implements ServerDnsAliases {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverKeys.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverKeys.ts
@@ -239,7 +239,7 @@ export class ServerKeysImpl implements ServerKeys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -334,7 +334,7 @@ export class ServerKeysImpl implements ServerKeys {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverSecurityAlertPolicies.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverSecurityAlertPolicies.ts
@@ -225,7 +225,7 @@ export class ServerSecurityAlertPoliciesImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverTrustGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/serverTrustGroups.ts
@@ -317,7 +317,7 @@ export class ServerTrustGroupsImpl implements ServerTrustGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -409,7 +409,7 @@ export class ServerTrustGroupsImpl implements ServerTrustGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/servers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/servers.ts
@@ -286,7 +286,7 @@ export class ServersImpl implements Servers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -373,7 +373,7 @@ export class ServersImpl implements Servers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -467,7 +467,7 @@ export class ServersImpl implements Servers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -574,7 +574,7 @@ export class ServersImpl implements Servers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncAgents.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncAgents.ts
@@ -325,7 +325,7 @@ export class SyncAgentsImpl implements SyncAgents {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -417,7 +417,7 @@ export class SyncAgentsImpl implements SyncAgents {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncGroups.ts
@@ -544,7 +544,7 @@ export class SyncGroupsImpl implements SyncGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -780,7 +780,7 @@ export class SyncGroupsImpl implements SyncGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -883,7 +883,7 @@ export class SyncGroupsImpl implements SyncGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -994,7 +994,7 @@ export class SyncGroupsImpl implements SyncGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncMembers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/syncMembers.ts
@@ -383,7 +383,7 @@ export class SyncMembersImpl implements SyncMembers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -492,7 +492,7 @@ export class SyncMembersImpl implements SyncMembers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -609,7 +609,7 @@ export class SyncMembersImpl implements SyncMembers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -771,7 +771,7 @@ export class SyncMembersImpl implements SyncMembers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/tdeCertificates.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/tdeCertificates.ts
@@ -93,7 +93,7 @@ export class TdeCertificatesImpl implements TdeCertificates {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/virtualClusters.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/virtualClusters.ts
@@ -298,7 +298,7 @@ export class VirtualClustersImpl implements VirtualClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -392,7 +392,7 @@ export class VirtualClustersImpl implements VirtualClusters {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/virtualNetworkRules.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/virtualNetworkRules.ts
@@ -224,7 +224,7 @@ export class VirtualNetworkRulesImpl implements VirtualNetworkRules {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -316,7 +316,7 @@ export class VirtualNetworkRulesImpl implements VirtualNetworkRules {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/workloadClassifiers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/workloadClassifiers.ts
@@ -263,7 +263,7 @@ export class WorkloadClassifiersImpl implements WorkloadClassifiers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -372,7 +372,7 @@ export class WorkloadClassifiersImpl implements WorkloadClassifiers {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/workloadGroups.ts
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/src/operations/workloadGroups.ts
@@ -248,7 +248,7 @@ export class WorkloadGroupsImpl implements WorkloadGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -351,7 +351,7 @@ export class WorkloadGroupsImpl implements WorkloadGroups {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/src/operations/blobContainers.ts
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/src/operations/blobContainers.ts
@@ -571,7 +571,7 @@ export class BlobContainersImpl implements BlobContainers {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/src/operations/storageAccounts.ts
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/src/operations/storageAccounts.ts
@@ -292,7 +292,7 @@ export class StorageAccountsImpl implements StorageAccounts {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -574,7 +574,7 @@ export class StorageAccountsImpl implements StorageAccounts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -670,7 +670,7 @@ export class StorageAccountsImpl implements StorageAccounts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -765,7 +765,7 @@ export class StorageAccountsImpl implements StorageAccounts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -864,7 +864,7 @@ export class StorageAccountsImpl implements StorageAccounts {
       intervalInMs: options?.updateIntervalInMs,
       resourceLocationConfig: "location"
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServiceCertificateOrders.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServiceCertificateOrders.ts
@@ -420,7 +420,7 @@ export class AppServiceCertificateOrdersImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -604,7 +604,7 @@ export class AppServiceCertificateOrdersImpl
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServiceEnvironments.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServiceEnvironments.ts
@@ -2114,7 +2114,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2199,7 +2199,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2340,7 +2340,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2538,7 +2538,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2810,7 +2810,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2914,7 +2914,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3041,7 +3041,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3146,7 +3146,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -3280,7 +3280,7 @@ export class AppServiceEnvironmentsImpl implements AppServiceEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServicePlans.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/appServicePlans.ts
@@ -675,7 +675,7 @@ export class AppServicePlansImpl implements AppServicePlans {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/domains.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/domains.ts
@@ -505,7 +505,7 @@ export class DomainsImpl implements Domains {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/kubeEnvironments.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/kubeEnvironments.ts
@@ -289,7 +289,7 @@ export class KubeEnvironmentsImpl implements KubeEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -374,7 +374,7 @@ export class KubeEnvironmentsImpl implements KubeEnvironments {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/staticSites.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/staticSites.ts
@@ -1114,7 +1114,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1200,7 +1200,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1410,7 +1410,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1664,7 +1664,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1790,7 +1790,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -1997,7 +1997,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2089,7 +2089,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2185,7 +2185,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2274,7 +2274,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2499,7 +2499,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2597,7 +2597,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2777,7 +2777,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -2893,7 +2893,7 @@ export class StaticSitesImpl implements StaticSites {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
@@ -6677,7 +6677,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -6940,7 +6940,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -7521,7 +7521,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -8171,7 +8171,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -8344,7 +8344,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -8989,7 +8989,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -9324,7 +9324,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -9422,7 +9422,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -9669,7 +9669,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10068,7 +10068,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10166,7 +10166,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10546,7 +10546,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10633,7 +10633,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10721,7 +10721,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -10853,7 +10853,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -11008,7 +11008,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -11302,7 +11302,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -11972,7 +11972,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -12668,7 +12668,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -12855,7 +12855,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -13586,7 +13586,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -14131,7 +14131,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -14595,7 +14595,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -14704,7 +14704,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15135,7 +15135,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15228,7 +15228,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15321,7 +15321,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15465,7 +15465,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15603,7 +15603,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15763,7 +15763,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -15924,7 +15924,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -16507,7 +16507,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -16653,7 +16653,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 
@@ -16799,7 +16799,7 @@ export class WebAppsImpl implements WebApps {
       restoreFrom: options?.resumeFrom,
       intervalInMs: options?.updateIntervalInMs
     });
-    await poller.poll();
+
     return poller;
   }
 

--- a/packages/cadl-rlc-test/test/anomalyDetector/spec/univariate/routes.cadl
+++ b/packages/cadl-rlc-test/test/anomalyDetector/spec/univariate/routes.cadl
@@ -7,6 +7,25 @@ using Cadl.Http;
 
 namespace AnomalyDetector.Univariate;
 
+interface Widgets {
+  @doc("Gets status of a Widget operation.")
+  getWidgetOperationStatus is GetResourceOperationStatus<Widget>;
+
+  @doc("Fetch a Widget by name.")
+  getWidget is ResourceRead<Widget>;
+
+  @doc("Creates or updates a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  createOrUpdateWidget is LongRunningResourceCreateOrUpdate<Widget>;
+
+  @doc("Delete a Widget asynchronously.")
+  @pollingOperation(Widgets.getWidgetOperationStatus)
+  deleteWidget is LongRunningResourceDelete<Widget>;
+
+  @doc("List Widget resources.")
+  listWidgets is ResourceList<Widget>;
+}
+
 @post
 @route("timeseries/entire/detect")
 @summary("Detect anomalies for the entire series in batch.")

--- a/packages/cadl-rlc-test/test/anomalyDetector/spec/univariate/routes.cadl
+++ b/packages/cadl-rlc-test/test/anomalyDetector/spec/univariate/routes.cadl
@@ -7,25 +7,6 @@ using Cadl.Http;
 
 namespace AnomalyDetector.Univariate;
 
-interface Widgets {
-  @doc("Gets status of a Widget operation.")
-  getWidgetOperationStatus is GetResourceOperationStatus<Widget>;
-
-  @doc("Fetch a Widget by name.")
-  getWidget is ResourceRead<Widget>;
-
-  @doc("Creates or updates a Widget asynchronously.")
-  @pollingOperation(Widgets.getWidgetOperationStatus)
-  createOrUpdateWidget is LongRunningResourceCreateOrUpdate<Widget>;
-
-  @doc("Delete a Widget asynchronously.")
-  @pollingOperation(Widgets.getWidgetOperationStatus)
-  deleteWidget is LongRunningResourceDelete<Widget>;
-
-  @doc("List Widget resources.")
-  listWidgets is ResourceList<Widget>;
-}
-
 @post
 @route("timeseries/entire/detect")
 @summary("Detect anomalies for the entire series in batch.")


### PR DESCRIPTION
The original pr is https://github.com/Azure/autorest.typescript/pull/1586 and it has below ci failures:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=2034536&view=logs&j=71cc2e7d-6454-5bf0-71b5-f1eef07a6c23&t=f2857310-5d68-5640-1409-0ba88dcfe076&l=1299

I fixed this failures by removing the `poll()` call, https://github.com/joheredi/autorest.typescript/pull/2/files#diff-30776bf0dca3d9ed8226f91676dbb870808482bad53e453d798160add8cca23e. 

Because I notice it would introduce one more http request which is not expected when we are in sync way to handle LRO request. But I am not sure this is correct or not when we call `createHttpPoller`.

@deyaaeldeen Could you help explain the differences between `poller.poll()`, `poller.pollUntilDone` and review this change?

```
await poller.poll();
```

After this fix the ci passed: https://github.com/Azure/autorest.typescript/pull/1689.


/cc @qiaozha

